### PR TITLE
Save player progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ frequency.
 `quit` and `logout` are used.
 * Thanks to the above, when a player reconnects they will spawn in the last room they
 occupied.
+* Server command `stop` was discovered to be broken, in the sense that once stopped,
+the server cannot be `start`ed again without terminating the program and running it
+again. This will be fixed later, as it doesn't currently pose a development
+complication.
 
 ### 2023-07-15
 * New commands available: `look, exits, north, south, east, west`

--- a/README.md
+++ b/README.md
@@ -30,11 +30,21 @@ about but haven't gotten the professional opportunity to try.
 
 ## Current state:
 
+### 2023-07-16
+* New command available: `quit`
+* Server now has the ability to schedule "tick" timers, that are processed with varying
+frequency.
+* The current player room is persisted every minute, if a disconnection occurs, or when
+`quit` and `logout` are used.
+* Thanks to the above, when a player reconnects they will spawn in the last room they
+occupied.
+
 ### 2023-07-15
 * New commands available: `look, exits, north, south, east, west`
 * A small set of sample rooms were created to test navigation.
 * Basic player navigation has been implemented, with the exceptions of `up` and `down`.
-* "Local" messages have been completed, and now only print to occupants of the room they were executed within.
+* "Local" messages have been completed, and now only print to occupants of the room they
+were executed within.
 
 ### 2023-07-13
 * The project can be loaded via Dev Container in VSCode.

--- a/cibo/__main__.py
+++ b/cibo/__main__.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         "Accepted commands:\n\n"
         "create_db    create the necessary db and tables\n"
         "start        start the server\n"
-        "stop         stop the server\n"
+        "stop         stop the server (currently broken, can't be started again)\n"
         "exit         stop the server if running, and exit this program\n"
     )
 

--- a/cibo/actions/__init__.py
+++ b/cibo/actions/__init__.py
@@ -15,6 +15,8 @@ from cibo.actions._connect import _Connect
 from cibo.actions._disconnect import _Disconnect
 from cibo.actions._error import _Error
 from cibo.actions._prompt import _Prompt
+from cibo.actions._tick_minute import _TickMinute
+from cibo.actions._tick_second import _TickSecond
 from cibo.actions.exits import Exits
 from cibo.actions.finalize import Finalize
 from cibo.actions.login import Login
@@ -25,7 +27,7 @@ from cibo.actions.quit import Quit
 from cibo.actions.register import Register
 from cibo.actions.say import Say
 
-_ = Action, _Connect, _Disconnect, _Error, _Prompt
+_ = Action, _Connect, _Disconnect, _Error, _Prompt, _TickSecond, _TickMinute
 
 ACTIONS = [
     Exits,

--- a/cibo/actions/_disconnect.py
+++ b/cibo/actions/_disconnect.py
@@ -16,7 +16,9 @@ class _Disconnect(Action):
         return []
 
     def process(self, client: Client, _command: Optional[str], _args: List[str]):
-        if client.player:
+        if client.is_logged_in and client.player:
+            client.player.save()
+
             self._send.local(
                 client.player.current_room_id,
                 f"You watch in horror as [cyan]{client.player.name}[/] "

--- a/cibo/actions/_tick_minute.py
+++ b/cibo/actions/_tick_minute.py
@@ -1,0 +1,20 @@
+"""Repetative logic that is carried out every minute."""
+
+from typing import List, Optional
+
+from cibo.actions import Action
+from cibo.client import Client
+
+
+class _TickMinute(Action):
+    """Repetative logic that is carried out every minute."""
+
+    def aliases(self) -> List[str]:
+        return []
+
+    def required_args(self) -> List[str]:
+        return []
+
+    def process(self, client: Client, _command: Optional[str], _args: List[str]):
+        if client.is_logged_in and client.player:
+            client.player.save()

--- a/cibo/actions/_tick_second.py
+++ b/cibo/actions/_tick_second.py
@@ -1,0 +1,19 @@
+"""Repetative logic that is carried out every second."""
+
+from typing import List, Optional
+
+from cibo.actions import Action
+from cibo.client import Client
+
+
+class _TickSecond(Action):
+    """Repetative logic that is carried out every second."""
+
+    def aliases(self) -> List[str]:
+        return []
+
+    def required_args(self) -> List[str]:
+        return []
+
+    def process(self, _client: Client, _command: Optional[str], _args: List[str]):
+        pass

--- a/cibo/actions/finalize.py
+++ b/cibo/actions/finalize.py
@@ -29,7 +29,7 @@ class Finalize(Action):
             self._send.private(
                 client,
                 "You'll need to [green]register[/] before you can "
-                "[green]finalize#NOCLOR#.",
+                "[green]finalize[/].",
             )
             return
 

--- a/cibo/actions/login.py
+++ b/cibo/actions/login.py
@@ -70,7 +70,8 @@ class Login(Action):
         # join the world and look at the room we left off in
         self._send.private(
             client,
-            "You awaken from a pleasant dream, disappointed. You have a look around...",
+            "You take the [red]red pill[/]. You have a look around, to see how deep "
+            "the rabbit hole goes...",
             prompt=False,
         )
 

--- a/cibo/actions/logout.py
+++ b/cibo/actions/logout.py
@@ -1,5 +1,6 @@
 """Log out of the current player session."""
 
+from time import sleep
 from typing import List
 
 from cibo.actions import Action, _Connect
@@ -24,6 +25,7 @@ class Logout(Action):
         player_room = client.player.current_room_id
 
         client.login_state = ClientLoginState.PRE_LOGIN
+        client.player.save()
         client.player = None
 
         self._send.local(
@@ -39,6 +41,8 @@ class Logout(Action):
             "You slowly fade away into obscurity, like you always feared you would...",
             prompt=False,
         )
+
+        sleep(1)
 
         # process the connection Action, so the client knows they can now register
         # or login again

--- a/cibo/actions/quit.py
+++ b/cibo/actions/quit.py
@@ -1,19 +1,45 @@
 """Quits the game and disconnects the client."""
 
+from time import sleep
 from typing import List
 
 from cibo.actions import Action
-from cibo.client import Client
+from cibo.client import Client, ClientLoginState
 
 
 class Quit(Action):
     """Quits the game and disconnects the client."""
 
     def aliases(self) -> List[str]:
-        return []
+        return ["quit"]
 
     def required_args(self) -> List[str]:
         return []
 
-    def process(self, _client: Client, _command: str, _args: List[str]):
-        pass
+    def process(self, client: Client, _command: str, _args: List[str]):
+        if client.is_logged_in and client.player:
+            player_name = client.player.name
+            player_room = client.player.current_room_id
+
+            client.login_state = ClientLoginState.PRE_LOGIN
+            client.player.save()
+            client.player = None
+
+            self._send.local(
+                player_room,
+                f'[cyan]{player_name}[/] yells, "Thank you Wisconsin!" They '
+                "then proceed to drop their microphone, and walk off the stage.",
+                [client],
+            )
+
+        self._send.private(
+            client,
+            "You take the [blue]blue pill[/]. You wake up in your bed and believe "
+            "whatever you want to believe. You choose to believe that your parents are "
+            "proud of you.\n",
+            prompt=False,
+        )
+
+        sleep(1)
+
+        client.disconnect()

--- a/cibo/events/__init__.py
+++ b/cibo/events/__init__.py
@@ -10,5 +10,6 @@ from cibo.events.__event__ import Event
 from cibo.events.connect import Connect
 from cibo.events.disconnect import Disconnect
 from cibo.events.input import Input
+from cibo.events.tick import Tick
 
-_ = Event, Connect, Disconnect, Input
+_ = Event, Connect, Disconnect, Input, Tick

--- a/cibo/events/tick.py
+++ b/cibo/events/tick.py
@@ -1,0 +1,61 @@
+"""Tick timers, that execute recurring Actions with varying frequency."""
+
+
+from threading import Thread
+
+from schedule import every, run_pending
+
+from cibo.actions import Action, _TickMinute, _TickSecond
+from cibo.events import Event
+from cibo.resources.world import World
+from cibo.telnet import TelnetServer
+
+
+class Tick(Event):
+    """Tick timers, that execute recurring Actions with varying frequency."""
+
+    def __init__(self, telnet: TelnetServer, world: World):
+        super().__init__(telnet, world)
+
+        # schedule each of our tick Actions for processing
+        every().second.do(
+            self._process_tick, self._tick_second, self._telnet, self._world
+        )
+        every().minute.do(
+            self._process_tick, self._tick_minute, self._telnet, self._world
+        )
+
+    @staticmethod
+    def _process_tick(action: type[Action], telnet: TelnetServer, world: World):
+        """This processes our tick schedules in parallel, rather than serially.
+        That way our intervals are as accurate as possible.
+
+        Args:
+            action (type[Action]): The tick Action to process.
+            telnet (TelnetServer): The Telnet server to use when executing the Action.
+            world (World): The World as we know it.
+        """
+
+        thread = Thread(target=action, args=[telnet, world])
+        thread.start()
+
+    @staticmethod
+    def _tick_second(telnet: TelnetServer, world: World):
+        """A tick scheduled for every second."""
+
+        for client in telnet.get_connected_clients():
+            _TickSecond(telnet, world).process(client, None, [])
+
+    @staticmethod
+    def _tick_minute(telnet: TelnetServer, world: World):
+        """A tick scheduled for every minute."""
+
+        for client in telnet.get_connected_clients():
+            _TickMinute(telnet, world).process(client, None, [])
+
+    def process(
+        self,
+    ) -> None:
+        # don't tick if no clients are connected, to conserve system resources
+        if len(self._telnet.get_connected_clients()) > 0:
+            run_pending()

--- a/cibo/telnet.py
+++ b/cibo/telnet.py
@@ -262,6 +262,12 @@ class TelnetServer:
     def _check_for_messages(self) -> None:
         # go through all the clients
         for client in self._clients:
+            # do an initial check to see if the client disconnected, but we just
+            # haven't processed it yet.
+            if client.socket.fileno() < 0:
+                self._handle_disconnect(client)
+                continue
+
             # we use 'select' to test whether there is data waiting to be read
             # from the client socket. The function takes 3 lists of sockets,
             # the first being those to test for readability. It returns 3 list

--- a/poetry.lock
+++ b/poetry.lock
@@ -503,13 +503,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.8.1"
+version = "3.9.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.8.1-py3-none-any.whl", hash = "sha256:cec7b889196b9144d088e4c57d9ceef7374f6c39694ad1577a0aab50d27ea28c"},
-    {file = "platformdirs-3.8.1.tar.gz", hash = "sha256:f87ca4fcff7d2b0f81c6a748a77973d7af0f4d526f98f308477c3c436c74d528"},
+    {file = "platformdirs-3.9.1-py3-none-any.whl", hash = "sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f"},
+    {file = "platformdirs-3.9.1.tar.gz", hash = "sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421"},
 ]
 
 [package.extras]
@@ -782,6 +782,17 @@ github = ["jinja2 (>=3.1.0)", "pygithub (>=1.43.3)"]
 gitlab = ["python-gitlab (>=1.3.0)"]
 
 [[package]]
+name = "schedule"
+version = "1.2.0"
+description = "Job scheduling for humans."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "schedule-1.2.0-py2.py3-none-any.whl", hash = "sha256:415908febaba0bc9a7c727a32efb407d646fe994367ef9157d123aabbe539ea8"},
+    {file = "schedule-1.2.0.tar.gz", hash = "sha256:b4ad697aafba7184c9eb6a1e2ebc41f781547242acde8ceae9a0a25b04c0922d"},
+]
+
+[[package]]
 name = "setuptools"
 version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -912,4 +923,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.4"
-content-hash = "c00cbe8e5a28a824486a1d3245bc4c36e953873101910278a01f417b8fcbdc7d"
+content-hash = "89b18c3e2ad3cf8497f1452540a81fc306e1390c3b14a15150c19ecfd4c61dc6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ peewee = "3.16.2"
 python = "3.11.4"
 python-dotenv = "1.0.0"
 rich = "13.4.2"
+schedule = "1.2.0"
 
 [tool.poetry.dev-dependencies]
 black = "23.3.0"


### PR DESCRIPTION
* New command available: `quit`
* Server now has the ability to schedule "tick" timers, that are processed with varying
frequency.
* The current player room is persisted every minute, if a disconnection occurs, or when
`quit` and `logout` are used.
* Thanks to the above, when a player reconnects they will spawn in the last room they
occupied.
* Server command `stop` was discovered to be broken, in the sense that once stopped,
the server cannot be `start`ed again without terminating the program and running it
again. This will be fixed later, as it doesn't currently pose a development
complication.