### PR TITLE
Look at items and NPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ about but haven't gotten the professional opportunity to try.
 
 ## Current state:
 
+### 2024-01-01
+* Happy new year!
+* Added the ability to `look <target>` at items in the current room, player inventory,
+or NPCs in the current room, to see their descriptions.
+
 ### 2023-09-06
 * Added basic, stationary NPCs. They can't be interacted with yet, but soon enough.
 * Added the ability to create item and NPC spawning rules, to populate specific rooms

--- a/cibo/actions/__action__.py
+++ b/cibo/actions/__action__.py
@@ -10,6 +10,7 @@ from cibo.password import Password
 from cibo.resources.doors import Doors
 from cibo.resources.items import Items
 from cibo.resources.npcs import Npcs
+from cibo.resources.resources import Resources
 from cibo.resources.rooms import Rooms
 
 
@@ -28,6 +29,17 @@ class Action(ABC):
         self._output = self._server_config.output
 
         self._password_hasher = Password()
+
+    @property
+    def resources(self) -> Resources:
+        """Resource helper methods that aren't necesarily associated with just one
+        resource type.
+
+        Returns:
+            Resources: The helper methods.
+        """
+
+        return self._world.resources
 
     @property
     def rooms(self) -> Rooms:

--- a/cibo/actions/__action__.py
+++ b/cibo/actions/__action__.py
@@ -9,6 +9,7 @@ from cibo.output import Output
 from cibo.password import Password
 from cibo.resources.doors import Doors
 from cibo.resources.items import Items
+from cibo.resources.npcs import Npcs
 from cibo.resources.rooms import Rooms
 
 
@@ -56,6 +57,16 @@ class Action(ABC):
         """
 
         return self._world.items
+
+    @property
+    def npcs(self) -> Npcs:
+        """All the NPCs in the world.
+
+        Returns:
+            Npcs: The NPCs.
+        """
+
+        return self._world.npcs
 
     @property
     def output(self) -> Output:

--- a/cibo/actions/commands/inventory.py
+++ b/cibo/actions/commands/inventory.py
@@ -32,7 +32,9 @@ class Inventory(Action):
             str: The items in the player inventory.
         """
 
-        inventory_items = self.items.get_from_dataset(client.player.inventory)
+        inventory_items = [
+            item.name for item in self.items.get_from_dataset(client.player.inventory)
+        ]
 
         inventory = "\n".join([str(item).capitalize() for item in inventory_items])
 

--- a/cibo/actions/commands/inventory.py
+++ b/cibo/actions/commands/inventory.py
@@ -32,9 +32,7 @@ class Inventory(Action):
             str: The items in the player inventory.
         """
 
-        inventory_items = [
-            self.items.get_by_id(item.item_id).name for item in client.player.inventory
-        ]
+        inventory_items = self.items.get_from_dataset(client.player.inventory)
 
         inventory = "\n".join([str(item).capitalize() for item in inventory_items])
 

--- a/cibo/actions/commands/look.py
+++ b/cibo/actions/commands/look.py
@@ -48,7 +48,7 @@ class Look(Action):
         inventory, or an NPC in the room. In that order.
         """
 
-        resource = self.items.get_by_name(
+        resource = self.resources.get_by_name(
             (
                 self._get_room_items(client)
                 + self._get_player_items(client)

--- a/cibo/actions/commands/look.py
+++ b/cibo/actions/commands/look.py
@@ -117,6 +117,9 @@ class Look(Action):
 
         if name_segments[0].isdigit():
             try:
+                # we expect the initial index to be 1 (not zero) because it's
+                # more intuitive from a user perspective, so we have to decrease it
+                # here by 1 to be accurate against our list
                 return results[(int(name_segments[0]) - 1)]
 
             except IndexError:

--- a/cibo/actions/commands/look.py
+++ b/cibo/actions/commands/look.py
@@ -105,6 +105,7 @@ class Look(Action):
         # after splitting on periods in the name, if the first character is a number,
         # we want to be able to target that specific index in the resources list
         if name_segments[0].isdigit():
+            # a specified index of 0 (zero) returns none -- see the next comment below
             if len(name_segments) > 1 and int(name_segments[0]) > 0:
                 search_name = name_segments[1]
             else:

--- a/cibo/actions/commands/look.py
+++ b/cibo/actions/commands/look.py
@@ -48,7 +48,7 @@ class Look(Action):
         inventory, or an NPC in the room. In that order.
         """
 
-        resource = self._get_resource_by_name(
+        resource = self.get_resource_by_name(
             (
                 self._get_room_items(client)
                 + self._get_player_items(client)
@@ -96,9 +96,25 @@ class Look(Action):
     def _get_player_items(self, client: Client) -> List[Item]:
         return [self.items.get_by_id(item.item_id) for item in client.player.inventory]
 
-    def _get_resource_by_name(
+    # TODO: this method will be useful for many other actions in the future, at which
+    # point it should be moved someplace more common
+    def get_resource_by_name(
         self, resources: List[Union[Item, Npc]], name: str
     ) -> Optional[Union[Item, Npc]]:
+        """Finds a resource in a list of resources, with a name that matches or
+        contains the provided string. If the string starts with a number followed
+        by a period, that number is used as an index assuming there are multiple
+        matches.
+
+
+        Args:
+            resources (List[Union[Item, Npc]]): The resources to search against.
+            name (str): What to search for in the resource name.
+
+        Returns:
+            Optional[Union[Item, Npc]]: The matching resource, if one is found.
+        """
+
         search_name = name
         name_segments = name.split(".")
 

--- a/cibo/actions/commands/open.py
+++ b/cibo/actions/commands/open.py
@@ -55,7 +55,7 @@ class Open(Action):
             f"{door_name.capitalize()} opens.",
         )
 
-    def door_is_open(self, door_name: str) -> str:
+    def door_is_open_message(self, door_name: str) -> str:
         """The door is already open."""
 
         return f"{door_name.capitalize()} is already open."
@@ -93,7 +93,9 @@ class Open(Action):
             )
 
         except DoorIsOpen:
-            self.output.send_private_message(client, self.door_is_open(door.name))
+            self.output.send_private_message(
+                client, self.door_is_open_message(door.name)
+            )
 
         except DoorIsClosed:
             door.open_()

--- a/cibo/exception.py
+++ b/cibo/exception.py
@@ -147,6 +147,12 @@ class RegionNotFound(Exception):
     pass
 
 
+class ResourceNotFound(Exception):
+    """Raised if no general matching resource is found."""
+
+    pass
+
+
 class RoomItemNotFound(Exception):
     """Raised if no item with the given name is found in the current room."""
 

--- a/cibo/exception.py
+++ b/cibo/exception.py
@@ -147,12 +147,6 @@ class RegionNotFound(Exception):
     pass
 
 
-class ResourceNotFound(Exception):
-    """Raised if no general matching resource is found."""
-
-    pass
-
-
 class RoomItemNotFound(Exception):
     """Raised if no item with the given name is found in the current room."""
 

--- a/cibo/resources/__resource__.py
+++ b/cibo/resources/__resource__.py
@@ -7,7 +7,7 @@ Some examples of a resource would be: a room, door, item, or NPC.
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from cibo.models.door import Door
 from cibo.models.item import Item
@@ -51,3 +51,55 @@ class Resource(ABC):
         self, resource: dict
     ) -> Union[Item, Room, Door, Sector, Region, Npc, Spawn]:  # pytest: no cover
         pass
+
+
+class Composite:
+    """Resource composite methods, that we don't necessarily want inherited by all
+    resource types.
+    """
+
+    def get_by_name(
+        self, resources: List[Union[Item, Npc]], name: str
+    ) -> Optional[Union[Item, Npc]]:
+        """Finds a resource in a list of resources, with a name that matches or
+        contains the provided string. If the string starts with a number followed
+        by a period, that number is used as an index assuming there are multiple
+        matches.
+
+
+        Args:
+            resources (List[Union[Item, Npc]]): The resources to search against.
+            name (str): What to search for in the resource name.
+
+        Returns:
+            Optional[Union[Item, Npc]]: The matching resource, if one is found.
+        """
+
+        search_name = name
+        name_segments = name.split(".")
+
+        # after splitting on periods in the name, if the first character is a number,
+        # we want to be able to target that specific index in the resources list
+        if name_segments[0].isdigit():
+            # a specified index of 0 (zero) returns none -- see the next comment below
+            if len(name_segments) > 1 and int(name_segments[0]) > 0:
+                search_name = name_segments[1]
+            else:
+                return None
+
+        results = [resource for resource in resources if search_name in resource.name]
+
+        if not results:
+            return None
+
+        if name_segments[0].isdigit():
+            try:
+                # we expect the initial index to be 1 (not zero) because it's
+                # more intuitive from a user perspective, so we have to decrease it
+                # here by 1 to be accurate against our list
+                return results[(int(name_segments[0]) - 1)]
+
+            except IndexError:
+                return None
+
+        return results[0]

--- a/cibo/resources/__resource__.py
+++ b/cibo/resources/__resource__.py
@@ -22,7 +22,7 @@ class Resource(ABC):
     """An object that exists in the world."""
 
     def _generate_resources(self, filename: str) -> list:
-        """Generate all the resources, from the local JSON file that houses them,
+        """Generate all the resources, from the local JSON file that houses them.
 
         Returns:
             List[Room]: All the resources.

--- a/cibo/resources/__resource__.py
+++ b/cibo/resources/__resource__.py
@@ -7,7 +7,7 @@ Some examples of a resource would be: a room, door, item, or NPC.
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Union
 
 from cibo.models.door import Door
 from cibo.models.item import Item
@@ -51,55 +51,3 @@ class Resource(ABC):
         self, resource: dict
     ) -> Union[Item, Room, Door, Sector, Region, Npc, Spawn]:  # pytest: no cover
         pass
-
-
-class Composite:
-    """Resource composite methods, that we don't necessarily want inherited by all
-    resource types.
-    """
-
-    def get_by_name(
-        self, resources: List[Union[Item, Npc]], name: str
-    ) -> Optional[Union[Item, Npc]]:
-        """Finds a resource in a list of resources, with a name that matches or
-        contains the provided string. If the string starts with a number followed
-        by a period, that number is used as an index assuming there are multiple
-        matches.
-
-
-        Args:
-            resources (List[Union[Item, Npc]]): The resources to search against.
-            name (str): What to search for in the resource name.
-
-        Returns:
-            Optional[Union[Item, Npc]]: The matching resource, if one is found.
-        """
-
-        search_name = name
-        name_segments = name.split(".")
-
-        # after splitting on periods in the name, if the first character is a number,
-        # we want to be able to target that specific index in the resources list
-        if name_segments[0].isdigit():
-            # a specified index of 0 (zero) returns none -- see the next comment below
-            if len(name_segments) > 1 and int(name_segments[0]) > 0:
-                search_name = name_segments[1]
-            else:
-                return None
-
-        results = [resource for resource in resources if search_name in resource.name]
-
-        if not results:
-            return None
-
-        if name_segments[0].isdigit():
-            try:
-                # we expect the initial index to be 1 (not zero) because it's
-                # more intuitive from a user perspective, so we have to decrease it
-                # here by 1 to be accurate against our list
-                return results[(int(name_segments[0]) - 1)]
-
-            except IndexError:
-                return None
-
-        return results[0]

--- a/cibo/resources/items.py
+++ b/cibo/resources/items.py
@@ -54,7 +54,7 @@ class Items(Resource):
         raise ItemNotFound
 
     def get_from_dataset(self, items_dataset: List[ItemData]) -> List[Item]:
-        """Compiles a list of items, using the IDS from a set of corresponding
+        """Compiles a list of items, using the IDs from a set of corresponding
         item data models.
 
         Args:

--- a/cibo/resources/items.py
+++ b/cibo/resources/items.py
@@ -10,7 +10,7 @@ from cibo.exception import ItemNotFound
 from cibo.models.data.item import Item as ItemData
 from cibo.models.description import EntityDescription
 from cibo.models.item import Item
-from cibo.resources.__resource__ import Composite, Resource
+from cibo.resources.__resource__ import Resource
 
 
 class Items(Resource):
@@ -18,7 +18,6 @@ class Items(Resource):
 
     def __init__(self, items_file: str):
         self._items: List[Item] = self._generate_resources(items_file)
-        self.get_by_name = Composite().get_by_name
 
     def _create_resource_from_dict(self, resource: dict) -> Item:
         item = resource

--- a/cibo/resources/items.py
+++ b/cibo/resources/items.py
@@ -7,9 +7,10 @@ This is a collection of all the items that exist in the world.
 from typing import List
 
 from cibo.exception import ItemNotFound
+from cibo.models.data.item import Item as ItemData
 from cibo.models.description import EntityDescription
 from cibo.models.item import Item
-from cibo.resources.__resource__ import Resource
+from cibo.resources.__resource__ import Composite, Resource
 
 
 class Items(Resource):
@@ -17,6 +18,7 @@ class Items(Resource):
 
     def __init__(self, items_file: str):
         self._items: List[Item] = self._generate_resources(items_file)
+        self.get_by_name = Composite().get_by_name
 
     def _create_resource_from_dict(self, resource: dict) -> Item:
         item = resource
@@ -51,3 +53,16 @@ class Items(Resource):
                 return item
 
         raise ItemNotFound
+
+    def get_from_dataset(self, items_dataset: List[ItemData]) -> List[Item]:
+        """Compiles a list of items, using the IDS from a set of corresponding
+        item data models.
+
+        Args:
+            items_dataset (List[ItemData]): The set of item data models.
+
+        Returns:
+            List[Item]: The compiled list of items.
+        """
+
+        return [self.get_by_id(item.item_id) for item in items_dataset]

--- a/cibo/resources/npcs.py
+++ b/cibo/resources/npcs.py
@@ -7,9 +7,10 @@ This is a collection of all the NPCs that exist in the world.
 from typing import List
 
 from cibo.exception import NpcNotFound
+from cibo.models.data.npc import Npc as NpcData
 from cibo.models.description import EntityDescription
 from cibo.models.npc import Npc
-from cibo.resources.__resource__ import Resource
+from cibo.resources.__resource__ import Composite, Resource
 
 
 class Npcs(Resource):
@@ -17,6 +18,7 @@ class Npcs(Resource):
 
     def __init__(self, npcs_file: str):
         self._npcs: List[Npc] = self._generate_resources(npcs_file)
+        self.get_by_name = Composite().get_by_name
 
     def _create_resource_from_dict(self, resource: dict) -> Npc:
         npc = resource
@@ -48,3 +50,16 @@ class Npcs(Resource):
                 return npc
 
         raise NpcNotFound
+
+    def get_from_dataset(self, npcs_dataset: List[NpcData]) -> List[Npc]:
+        """Compiles a list of NPCs, using the IDS from a set of corresponding
+        NPC data models.
+
+        Args:
+            npcs_dataset (List[NpcData]): The set of NPC data models.
+
+        Returns:
+            List[Npc]: The compiled list of NPCs.
+        """
+
+        return [self.get_by_id(npc.npc_id) for npc in npcs_dataset]

--- a/cibo/resources/npcs.py
+++ b/cibo/resources/npcs.py
@@ -51,7 +51,7 @@ class Npcs(Resource):
         raise NpcNotFound
 
     def get_from_dataset(self, npcs_dataset: List[NpcData]) -> List[Npc]:
-        """Compiles a list of NPCs, using the IDS from a set of corresponding
+        """Compiles a list of NPCs, using the IDs from a set of corresponding
         NPC data models.
 
         Args:

--- a/cibo/resources/npcs.py
+++ b/cibo/resources/npcs.py
@@ -10,7 +10,7 @@ from cibo.exception import NpcNotFound
 from cibo.models.data.npc import Npc as NpcData
 from cibo.models.description import EntityDescription
 from cibo.models.npc import Npc
-from cibo.resources.__resource__ import Composite, Resource
+from cibo.resources.__resource__ import Resource
 
 
 class Npcs(Resource):
@@ -18,7 +18,6 @@ class Npcs(Resource):
 
     def __init__(self, npcs_file: str):
         self._npcs: List[Npc] = self._generate_resources(npcs_file)
-        self.get_by_name = Composite().get_by_name
 
     def _create_resource_from_dict(self, resource: dict) -> Npc:
         npc = resource

--- a/cibo/resources/resources.py
+++ b/cibo/resources/resources.py
@@ -14,7 +14,7 @@ class Resources:
     """
 
     def get_by_name(
-        self, resources: List[Union[Item, Npc]], name: str
+        self, resources: List[Union[Item, Npc]], sub: str
     ) -> Optional[Union[Item, Npc]]:
         """Finds a resource in a list of resources, with a name that matches or
         contains the provided string. If the string starts with a number followed
@@ -30,29 +30,30 @@ class Resources:
             Optional[Union[Item, Npc]]: The matching resource, if one is found.
         """
 
-        search_name = name
-        name_segments = name.split(".")
+        _sub = sub
+        sub_segments = sub.split(".")
 
-        # after splitting on periods in the name, if the first character is a number,
-        # we want to be able to target that specific index in the resources list
-        if name_segments[0].isdigit():
-            # a specified index of 0 (zero) returns none -- see the next comment below
-            if len(name_segments) > 1 and int(name_segments[0]) > 0:
-                search_name = name_segments[1]
+        # after splitting on periods in the substring, if the first character is a
+        # number, we want to be able to target that specific index in the resources
+        # list
+        if sub_segments[0].isdigit():
+            # a specified index of 0 (zero) returns None -- see the next comment below
+            if len(sub_segments) > 1 and int(sub_segments[0]) > 0:
+                _sub = sub_segments[1]
             else:
                 return None
 
-        results = [resource for resource in resources if search_name in resource.name]
+        results = [resource for resource in resources if _sub in resource.name]
 
         if not results:
             return None
 
-        if name_segments[0].isdigit():
+        if sub_segments[0].isdigit():
             try:
                 # we expect the initial index to be 1 (not zero) because it's
                 # more intuitive from a user perspective, so we have to decrease it
                 # here by 1 to be accurate against our list
-                return results[(int(name_segments[0]) - 1)]
+                return results[(int(sub_segments[0]) - 1)]
 
             except IndexError:
                 return None

--- a/cibo/resources/resources.py
+++ b/cibo/resources/resources.py
@@ -17,14 +17,14 @@ class Resources:
         self, resources: List[Union[Item, Npc]], sub: str
     ) -> Optional[Union[Item, Npc]]:
         """Finds a resource in a list of resources, with a name that matches or
-        contains the provided string. If the string starts with a number followed
-        by a period, that number is used as an index assuming there are multiple
-        matches.
+        contains the provided substring. If the substring starts with a number
+        followed by a period, that number is used as an index assuming there are
+        multiple matches.
 
 
         Args:
             resources (List[Union[Item, Npc]]): The resources to search against.
-            name (str): What to search for in the resource name.
+            sub (str): What to search for in the resource name.
 
         Returns:
             Optional[Union[Item, Npc]]: The matching resource, if one is found.

--- a/cibo/resources/resources.py
+++ b/cibo/resources/resources.py
@@ -1,0 +1,60 @@
+"""Resource helper and batch methods that aren't necesarily associated with just one
+resource type.
+"""
+
+from typing import List, Optional, Union
+
+from cibo.models.item import Item
+from cibo.models.npc import Npc
+
+
+class Resources:
+    """Resource helper and batch methods that aren't necesarily associated with just
+    one resource type.
+    """
+
+    def get_by_name(
+        self, resources: List[Union[Item, Npc]], name: str
+    ) -> Optional[Union[Item, Npc]]:
+        """Finds a resource in a list of resources, with a name that matches or
+        contains the provided string. If the string starts with a number followed
+        by a period, that number is used as an index assuming there are multiple
+        matches.
+
+
+        Args:
+            resources (List[Union[Item, Npc]]): The resources to search against.
+            name (str): What to search for in the resource name.
+
+        Returns:
+            Optional[Union[Item, Npc]]: The matching resource, if one is found.
+        """
+
+        search_name = name
+        name_segments = name.split(".")
+
+        # after splitting on periods in the name, if the first character is a number,
+        # we want to be able to target that specific index in the resources list
+        if name_segments[0].isdigit():
+            # a specified index of 0 (zero) returns none -- see the next comment below
+            if len(name_segments) > 1 and int(name_segments[0]) > 0:
+                search_name = name_segments[1]
+            else:
+                return None
+
+        results = [resource for resource in resources if search_name in resource.name]
+
+        if not results:
+            return None
+
+        if name_segments[0].isdigit():
+            try:
+                # we expect the initial index to be 1 (not zero) because it's
+                # more intuitive from a user perspective, so we have to decrease it
+                # here by 1 to be accurate against our list
+                return results[(int(name_segments[0]) - 1)]
+
+            except IndexError:
+                return None
+
+        return results[0]

--- a/cibo/resources/world.py
+++ b/cibo/resources/world.py
@@ -9,6 +9,7 @@ from cibo.resources.doors import Doors
 from cibo.resources.items import Items
 from cibo.resources.npcs import Npcs
 from cibo.resources.regions import Regions
+from cibo.resources.resources import Resources
 from cibo.resources.rooms import Rooms
 from cibo.resources.sectors import Sectors
 from cibo.resources.spawns import Spawns
@@ -20,6 +21,8 @@ class World:
     """
 
     def __init__(self) -> None:
+        self.resources = Resources()
+
         self.regions = Regions(getenv("REGIONS_PATH", "/cibo/config/regions.json"))
         self.sectors = Sectors(
             getenv("SECTORS_PATH", "/cibo/config/sectors.json"), self.regions


### PR DESCRIPTION
* add the ability to `look <target>` to display the description of player inventory items, items in the current room, or NPCs in the current room
* if multiple matches exist, the search target can be prepended with a number and a period, to specify which result to look at: `look 2.fork`
* the result list is sorted according to the priority the AC dictates: 1. room items, 2. inventory items, 3. NPCs
* refactor the `Look` class a little bit, for better organization and readability
* create and expose the `Resources` class, which will house methods the aren't necessarily associated with only one resource type

Closes #27 