### PR TITLE
Clean up imports

### DIFF
--- a/cibo/__main__.py
+++ b/cibo/__main__.py
@@ -9,7 +9,7 @@ from time import sleep
 
 from cibo.models.server_config import ServerConfig
 from cibo.output import OutputProcessor
-from cibo.resources.world import World
+from cibo.resources import World
 from cibo.server import Server
 from cibo.telnet import TelnetServer
 

--- a/cibo/actions/__action__.py
+++ b/cibo/actions/__action__.py
@@ -3,15 +3,11 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from cibo.models.client import Client
+from cibo.models import Client
 from cibo.models.server_config import ServerConfig
 from cibo.output import OutputProcessor
 from cibo.password import Password
-from cibo.resources.doors import Doors
-from cibo.resources.items import Items
-from cibo.resources.npcs import Npcs
-from cibo.resources.resources import Resources
-from cibo.resources.rooms import Rooms
+from cibo.resources import Doors, Items, Npcs, Resources, Rooms
 
 
 class Action(ABC):

--- a/cibo/actions/__init__.py
+++ b/cibo/actions/__init__.py
@@ -6,3 +6,7 @@ Any newly added Action classes that will be driven by a command from the client 
 need to have their files created in the `cibo.actions.commands` path. Only then will
 the new action be available to clients.
 """
+
+from cibo.actions.connect import Connect
+from cibo.actions.disconnect import Disconnect
+from cibo.actions.error import Error

--- a/cibo/actions/commands/close.py
+++ b/cibo/actions/commands/close.py
@@ -13,8 +13,7 @@ from cibo.exception import (
     ExitNotFound,
     RoomNotFound,
 )
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Close(Action):

--- a/cibo/actions/commands/drop.py
+++ b/cibo/actions/commands/drop.py
@@ -9,9 +9,8 @@ from cibo.exception import (
     InventoryItemNotFound,
     ItemNotFound,
 )
-from cibo.models.client import Client
-from cibo.models.data.item import Item
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
+from cibo.models.data import Item
 
 
 class Drop(Action):

--- a/cibo/actions/commands/exits.py
+++ b/cibo/actions/commands/exits.py
@@ -4,9 +4,7 @@ from typing import List, Optional
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ClientNotLoggedIn, RoomNotFound
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
-from cibo.models.room import Room
+from cibo.models import Client, Message, MessageRoute, Room
 
 
 class Exits(Action):

--- a/cibo/actions/commands/finalize.py
+++ b/cibo/actions/commands/finalize.py
@@ -6,10 +6,8 @@ from peewee import IntegrityError
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ClientIsLoggedIn, PlayerAlreadyExists, PlayerNotRegistered
-from cibo.models.client import Client
-from cibo.models.data.item import Item
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
+from cibo.models.data import Item, Player
 
 
 class Finalize(Action):

--- a/cibo/actions/commands/get.py
+++ b/cibo/actions/commands/get.py
@@ -12,9 +12,8 @@ from cibo.exception import (
     ItemNotFound,
     RoomItemNotFound,
 )
-from cibo.models.client import Client
-from cibo.models.data.item import Item
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
+from cibo.models.data import Item
 
 
 class Get(Action):

--- a/cibo/actions/commands/inventory.py
+++ b/cibo/actions/commands/inventory.py
@@ -4,8 +4,7 @@ from typing import List
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ClientNotLoggedIn
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Inventory(Action):

--- a/cibo/actions/commands/login.py
+++ b/cibo/actions/commands/login.py
@@ -10,9 +10,8 @@ from cibo.exception import (
     PlayerNotFound,
     PlayerSessionActive,
 )
-from cibo.models.client import Client
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
+from cibo.models.data import Player
 
 
 class Login(Action):

--- a/cibo/actions/commands/logout.py
+++ b/cibo/actions/commands/logout.py
@@ -6,8 +6,7 @@ from typing import List, Tuple
 from cibo.actions.__action__ import Action
 from cibo.actions.connect import Connect
 from cibo.exception import ClientNotLoggedIn
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Logout(Action):

--- a/cibo/actions/commands/look.py
+++ b/cibo/actions/commands/look.py
@@ -6,13 +6,9 @@ from rich.panel import Panel
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ActionMissingArguments, ClientNotLoggedIn
-from cibo.models.client import Client
-from cibo.models.data.item import Item as ItemData
-from cibo.models.data.npc import Npc as NpcData
-from cibo.models.item import Item
-from cibo.models.message import Message, MessageRoute
-from cibo.models.npc import Npc
-from cibo.models.room import Room
+from cibo.models import Client, Item, Message, MessageRoute, Npc, Room
+from cibo.models.data import Item as ItemData
+from cibo.models.data import Npc as NpcData
 
 
 class Look(Action):

--- a/cibo/actions/commands/move.py
+++ b/cibo/actions/commands/move.py
@@ -13,8 +13,7 @@ from cibo.exception import (
     ExitNotFound,
     RoomNotFound,
 )
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Move(Action):

--- a/cibo/actions/commands/open.py
+++ b/cibo/actions/commands/open.py
@@ -13,8 +13,7 @@ from cibo.exception import (
     ExitNotFound,
     RoomNotFound,
 )
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Open(Action):

--- a/cibo/actions/commands/quit.py
+++ b/cibo/actions/commands/quit.py
@@ -5,8 +5,7 @@ from typing import List, Optional, Tuple
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ClientIsLoggedIn
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Quit(Action):

--- a/cibo/actions/commands/register.py
+++ b/cibo/actions/commands/register.py
@@ -6,9 +6,8 @@ from marshmallow import ValidationError
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ClientIsLoggedIn, PlayerAlreadyExists, PlayerNotFound
-from cibo.models.client import Client
-from cibo.models.data.player import Player, PlayerSchema
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
+from cibo.models.data import Player, PlayerSchema
 
 
 class Register(Action):

--- a/cibo/actions/commands/say.py
+++ b/cibo/actions/commands/say.py
@@ -4,8 +4,7 @@ from typing import List, Tuple
 
 from cibo.actions.__action__ import Action
 from cibo.exception import ActionMissingArguments, ClientNotLoggedIn
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Say(Action):

--- a/cibo/actions/connect.py
+++ b/cibo/actions/connect.py
@@ -5,8 +5,7 @@ from typing import List, Optional
 from rich.panel import Panel
 
 from cibo.actions.__action__ import Action
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Connect(Action):

--- a/cibo/actions/disconnect.py
+++ b/cibo/actions/disconnect.py
@@ -3,8 +3,7 @@
 from typing import List, Optional
 
 from cibo.actions.__action__ import Action
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Disconnect(Action):

--- a/cibo/actions/error.py
+++ b/cibo/actions/error.py
@@ -3,8 +3,7 @@
 from typing import List, Optional
 
 from cibo.actions.__action__ import Action
-from cibo.models.client import Client
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Client, Message, MessageRoute
 
 
 class Error(Action):

--- a/cibo/actions/scheduled/__init__.py
+++ b/cibo/actions/scheduled/__init__.py
@@ -1,3 +1,6 @@
 """Actions that are scheduled by the tick event, to be processed at varying
 frequency.
 """
+
+from cibo.actions.scheduled.every_minute import EveryMinute
+from cibo.actions.scheduled.every_second import EverySecond

--- a/cibo/actions/scheduled/every_minute.py
+++ b/cibo/actions/scheduled/every_minute.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 
 from cibo.actions.__action__ import Action
-from cibo.models.client import Client
+from cibo.models import Client
 
 
 class EveryMinute(Action):

--- a/cibo/actions/scheduled/every_second.py
+++ b/cibo/actions/scheduled/every_second.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 
 from cibo.actions.__action__ import Action
-from cibo.models.client import Client
+from cibo.models import Client
 
 
 class EverySecond(Action):

--- a/cibo/command.py
+++ b/cibo/command.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Type
 
 from cibo.actions.__action__ import Action
 from cibo.exception import CommandMissingArguments, CommandUnrecognized
-from cibo.models.client import Client
+from cibo.models import Client
 from cibo.models.server_config import ServerConfig
 
 

--- a/cibo/event.py
+++ b/cibo/event.py
@@ -8,9 +8,7 @@ in a FIFO order.
 
 from cibo.actions.commands import ACTIONS
 from cibo.command import CommandProcessor
-from cibo.events.connect import ConnectEvent
-from cibo.events.disconnect import DisconnectEvent
-from cibo.events.input import InputEvent
+from cibo.events import ConnectEvent, DisconnectEvent, InputEvent
 from cibo.models.server_config import ServerConfig
 
 

--- a/cibo/events/__init__.py
+++ b/cibo/events/__init__.py
@@ -5,3 +5,9 @@ tick timer or cron.
 Some events call actions directly. Others, like user input, will be ran through the
 CommandProcessor to determine which action should be called.
 """
+
+from cibo.events.connect import ConnectEvent
+from cibo.events.disconnect import DisconnectEvent
+from cibo.events.input import InputEvent
+from cibo.events.spawn import SpawnEvent
+from cibo.events.tick import TickEvent

--- a/cibo/events/connect.py
+++ b/cibo/events/connect.py
@@ -1,6 +1,6 @@
 """Clients who have connected to the server, since last update poll."""
 
-from cibo.actions.connect import Connect
+from cibo.actions import Connect
 from cibo.events.__event__ import Event
 
 

--- a/cibo/events/disconnect.py
+++ b/cibo/events/disconnect.py
@@ -1,6 +1,6 @@
 """Clients who have disconnected from the server, since last update poll."""
 
-from cibo.actions.disconnect import Disconnect
+from cibo.actions import Disconnect
 from cibo.events.__event__ import Event
 
 

--- a/cibo/events/input.py
+++ b/cibo/events/input.py
@@ -2,7 +2,7 @@
 CommandProcessor. If the input contains a valid command, further logic will be carried
 out."""
 
-from cibo.actions.error import Error
+from cibo.actions import Error
 from cibo.command import CommandProcessor
 from cibo.events.__event__ import Event
 from cibo.exception import (

--- a/cibo/events/spawn.py
+++ b/cibo/events/spawn.py
@@ -5,9 +5,8 @@ spawns the appropriate entity and amount into the world.
 from typing import List
 
 from cibo.events.__event__ import Event
-from cibo.models.data.item import Item
-from cibo.models.data.npc import Npc
-from cibo.models.spawn import Spawn, SpawnType
+from cibo.models import Spawn, SpawnType
+from cibo.models.data import Item, Npc
 
 
 class SpawnEvent(Event):

--- a/cibo/events/tick.py
+++ b/cibo/events/tick.py
@@ -6,8 +6,7 @@ from threading import Thread
 from schedule import every, run_pending
 
 from cibo.actions.__action__ import Action
-from cibo.actions.scheduled.every_minute import EveryMinute
-from cibo.actions.scheduled.every_second import EverySecond
+from cibo.actions.scheduled import EveryMinute, EverySecond
 from cibo.events.__event__ import Event
 from cibo.models.server_config import ServerConfig
 

--- a/cibo/models/__init__.py
+++ b/cibo/models/__init__.py
@@ -1,1 +1,15 @@
 """Data and object models, that together represent tangible world items and entities."""
+
+from cibo.models.client import Client, ClientLoginState
+from cibo.models.description import EntityDescription, RoomDescription
+from cibo.models.direction import Direction
+from cibo.models.door import Door, DoorFlag
+from cibo.models.flag import RoomFlag
+from cibo.models.item import Item
+from cibo.models.message import Message, MessageRoute
+from cibo.models.npc import Npc
+from cibo.models.prompt import Prompt
+from cibo.models.region import Region
+from cibo.models.room import Room, RoomExit
+from cibo.models.sector import Sector
+from cibo.models.spawn import Spawn, SpawnType

--- a/cibo/models/data/__init__.py
+++ b/cibo/models/data/__init__.py
@@ -1,1 +1,5 @@
 """Data models and schemas that are used to represent and validate a database object."""
+
+from cibo.models.data.item import Item
+from cibo.models.data.npc import Npc
+from cibo.models.data.player import Player, PlayerSchema

--- a/cibo/models/server_config.py
+++ b/cibo/models/server_config.py
@@ -5,7 +5,7 @@ server needs to function, and to process actions and events.
 from dataclasses import dataclass
 
 from cibo.output import OutputProcessor
-from cibo.resources.world import World
+from cibo.resources import World
 from cibo.telnet import TelnetServer
 
 

--- a/cibo/output.py
+++ b/cibo/output.py
@@ -6,14 +6,9 @@ supplied.
 from typing import Optional
 
 from cibo.exception import MessageRouteMissingParameters
-from cibo.models.client import Client
-from cibo.models.message import MessageRoute
-from cibo.outputs.private import Private
-from cibo.outputs.region import Region
-from cibo.outputs.room import Room
-from cibo.outputs.sector import Sector
-from cibo.outputs.server import Server
-from cibo.resources.world import World
+from cibo.models import Client, MessageRoute
+from cibo.outputs import Private, Region, Room, Sector, Server
+from cibo.resources import World
 from cibo.telnet import TelnetServer
 
 

--- a/cibo/outputs/__init__.py
+++ b/cibo/outputs/__init__.py
@@ -2,3 +2,9 @@
 Different output types will target different clients, depending on the routing
 supplied.
 """
+
+from cibo.outputs.private import Private
+from cibo.outputs.region import Region
+from cibo.outputs.room import Room
+from cibo.outputs.sector import Sector
+from cibo.outputs.server import Server

--- a/cibo/outputs/__output__.py
+++ b/cibo/outputs/__output__.py
@@ -2,8 +2,8 @@
 
 from abc import ABC, abstractmethod
 
-from cibo.models.message import Message, MessageRoute
-from cibo.resources.world import World
+from cibo.models import Message, MessageRoute
+from cibo.resources import World
 from cibo.telnet import TelnetServer
 
 

--- a/cibo/outputs/private.py
+++ b/cibo/outputs/private.py
@@ -1,6 +1,6 @@
 """Sends a private message, to a specific client."""
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from cibo.outputs.__output__ import Output
 
 

--- a/cibo/outputs/region.py
+++ b/cibo/outputs/region.py
@@ -1,7 +1,7 @@
 """Sends a message to clients whose player is currently located within the
 supplied region ID(s)."""
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from cibo.outputs.__output__ import Output
 
 

--- a/cibo/outputs/room.py
+++ b/cibo/outputs/room.py
@@ -1,7 +1,7 @@
 """Sends a message to clients whose player is currently located within the
 supplied room ID(s)."""
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from cibo.outputs.__output__ import Output
 
 

--- a/cibo/outputs/sector.py
+++ b/cibo/outputs/sector.py
@@ -1,7 +1,7 @@
 """Sends a message to clients whose player is currently located within the
 supplied sector ID(s)."""
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from cibo.outputs.__output__ import Output
 
 

--- a/cibo/outputs/server.py
+++ b/cibo/outputs/server.py
@@ -2,7 +2,7 @@
 player session.
 """
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from cibo.outputs.__output__ import Output
 
 

--- a/cibo/resources/__init__.py
+++ b/cibo/resources/__init__.py
@@ -3,3 +3,13 @@ interactable.
 
 Some examples of a resource would be: a room, door, item, or NPC.
 """
+
+from cibo.resources.doors import Doors
+from cibo.resources.items import Items
+from cibo.resources.npcs import Npcs
+from cibo.resources.regions import Regions
+from cibo.resources.resources import Resources
+from cibo.resources.rooms import Rooms
+from cibo.resources.sectors import Sectors
+from cibo.resources.spawns import Spawns
+from cibo.resources.world import World

--- a/cibo/resources/__resource__.py
+++ b/cibo/resources/__resource__.py
@@ -9,13 +9,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Union
 
-from cibo.models.door import Door
-from cibo.models.item import Item
-from cibo.models.npc import Npc
-from cibo.models.region import Region
-from cibo.models.room import Room
-from cibo.models.sector import Sector
-from cibo.models.spawn import Spawn
+from cibo.models import Door, Item, Npc, Region, Room, Sector, Spawn
 
 
 class Resource(ABC):

--- a/cibo/resources/doors.py
+++ b/cibo/resources/doors.py
@@ -8,7 +8,7 @@ This is a collection of all the doors that exist in the world.
 from typing import List
 
 from cibo.exception import DoorNotFound
-from cibo.models.door import Door, DoorFlag
+from cibo.models import Door, DoorFlag
 from cibo.resources.__resource__ import Resource
 
 

--- a/cibo/resources/items.py
+++ b/cibo/resources/items.py
@@ -7,9 +7,8 @@ This is a collection of all the items that exist in the world.
 from typing import List
 
 from cibo.exception import ItemNotFound
-from cibo.models.data.item import Item as ItemData
-from cibo.models.description import EntityDescription
-from cibo.models.item import Item
+from cibo.models import EntityDescription, Item
+from cibo.models.data import Item as ItemData
 from cibo.resources.__resource__ import Resource
 
 

--- a/cibo/resources/npcs.py
+++ b/cibo/resources/npcs.py
@@ -7,9 +7,8 @@ This is a collection of all the NPCs that exist in the world.
 from typing import List
 
 from cibo.exception import NpcNotFound
-from cibo.models.data.npc import Npc as NpcData
-from cibo.models.description import EntityDescription
-from cibo.models.npc import Npc
+from cibo.models import EntityDescription, Npc
+from cibo.models.data import Npc as NpcData
 from cibo.resources.__resource__ import Resource
 
 

--- a/cibo/resources/regions.py
+++ b/cibo/resources/regions.py
@@ -6,8 +6,7 @@ This is a collection of all the regions that exist in the world.
 from typing import List
 
 from cibo.exception import RegionNotFound
-from cibo.models.flag import RoomFlag
-from cibo.models.region import Region
+from cibo.models import Region, RoomFlag
 from cibo.resources.__resource__ import Resource
 
 

--- a/cibo/resources/resources.py
+++ b/cibo/resources/resources.py
@@ -4,8 +4,7 @@ resource type.
 
 from typing import List, Optional, Union
 
-from cibo.models.item import Item
-from cibo.models.npc import Npc
+from cibo.models import Item, Npc
 
 
 class Resources:

--- a/cibo/resources/rooms.py
+++ b/cibo/resources/rooms.py
@@ -7,10 +7,7 @@ This is a collection of all the rooms that exist in the world.
 from typing import List
 
 from cibo.exception import RoomNotFound
-from cibo.models.description import RoomDescription
-from cibo.models.direction import Direction
-from cibo.models.flag import RoomFlag
-from cibo.models.room import Room, RoomExit
+from cibo.models import Direction, Room, RoomDescription, RoomExit, RoomFlag
 from cibo.resources.__resource__ import Resource
 from cibo.resources.sectors import Sectors
 

--- a/cibo/resources/sectors.py
+++ b/cibo/resources/sectors.py
@@ -6,8 +6,7 @@ This is a collection of all the sectors that exist in the world.
 from typing import List
 
 from cibo.exception import SectorNotFound
-from cibo.models.flag import RoomFlag
-from cibo.models.sector import Sector
+from cibo.models import RoomFlag, Sector
 from cibo.resources.__resource__ import Resource
 from cibo.resources.regions import Regions
 

--- a/cibo/resources/spawns.py
+++ b/cibo/resources/spawns.py
@@ -5,7 +5,7 @@ This is a collection of all the spawn rules in the world.
 """
 from typing import List
 
-from cibo.models.spawn import Spawn, SpawnType
+from cibo.models import Spawn, SpawnType
 from cibo.resources.__resource__ import Resource
 from cibo.resources.items import Items
 from cibo.resources.npcs import Npcs

--- a/cibo/server.py
+++ b/cibo/server.py
@@ -10,11 +10,8 @@ from time import sleep
 from peewee import SqliteDatabase
 
 from cibo.event import EventProcessor
-from cibo.events.spawn import SpawnEvent
-from cibo.events.tick import TickEvent
-from cibo.models.data.item import Item
-from cibo.models.data.npc import Npc
-from cibo.models.data.player import Player
+from cibo.events import SpawnEvent, TickEvent
+from cibo.models.data import Item, Npc, Player
 from cibo.models.server_config import ServerConfig
 
 

--- a/tests/actions/commands/test_close.py
+++ b/tests/actions/commands/test_close.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import CloseActionFactory
+from tests.actions.conftest import CloseActionFactory
 
 
 class TestCloseAction(CloseActionFactory):

--- a/tests/actions/commands/test_close.py
+++ b/tests/actions/commands/test_close.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import CloseActionFactory
 
 

--- a/tests/actions/commands/test_drop.py
+++ b/tests/actions/commands/test_drop.py
@@ -1,6 +1,6 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
 from cibo.models.data import Item, Player
-from tests.conftest import DropActionFactory
+from tests.actions.conftest import DropActionFactory
 
 
 class TestDropAction(DropActionFactory):

--- a/tests/actions/commands/test_drop.py
+++ b/tests/actions/commands/test_drop.py
@@ -1,7 +1,5 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.data.item import Item
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
+from cibo.models.data import Item, Player
 from tests.conftest import DropActionFactory
 
 

--- a/tests/actions/commands/test_exits.py
+++ b/tests/actions/commands/test_exits.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import ExitsActionFactory
 
 

--- a/tests/actions/commands/test_exits.py
+++ b/tests/actions/commands/test_exits.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import ExitsActionFactory
+from tests.actions.conftest import ExitsActionFactory
 
 
 class TestExitsAction(ExitsActionFactory):

--- a/tests/actions/commands/test_finalize.py
+++ b/tests/actions/commands/test_finalize.py
@@ -1,6 +1,6 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
 from cibo.models.data import Player
-from tests.conftest import FinalizeActionFactory
+from tests.actions.conftest import FinalizeActionFactory
 
 
 class TestFinalizeAction(FinalizeActionFactory):

--- a/tests/actions/commands/test_finalize.py
+++ b/tests/actions/commands/test_finalize.py
@@ -1,6 +1,5 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
+from cibo.models.data import Player
 from tests.conftest import FinalizeActionFactory
 
 

--- a/tests/actions/commands/test_get.py
+++ b/tests/actions/commands/test_get.py
@@ -1,6 +1,6 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
 from cibo.models.data import Item, Player
-from tests.conftest import GetActionFactory
+from tests.actions.conftest import GetActionFactory
 
 
 class TestGetAction(GetActionFactory):

--- a/tests/actions/commands/test_get.py
+++ b/tests/actions/commands/test_get.py
@@ -1,7 +1,5 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.data.item import Item
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
+from cibo.models.data import Item, Player
 from tests.conftest import GetActionFactory
 
 

--- a/tests/actions/commands/test_inventory.py
+++ b/tests/actions/commands/test_inventory.py
@@ -1,6 +1,5 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
+from cibo.models.data import Player
 from tests.conftest import InventoryActionFactory
 
 

--- a/tests/actions/commands/test_inventory.py
+++ b/tests/actions/commands/test_inventory.py
@@ -1,6 +1,6 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
 from cibo.models.data import Player
-from tests.conftest import InventoryActionFactory
+from tests.actions.conftest import InventoryActionFactory
 
 
 class TestInventoryAction(InventoryActionFactory):

--- a/tests/actions/commands/test_login.py
+++ b/tests/actions/commands/test_login.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import LoginActionFactory
 
 

--- a/tests/actions/commands/test_login.py
+++ b/tests/actions/commands/test_login.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import LoginActionFactory
+from tests.actions.conftest import LoginActionFactory
 
 
 class TestLoginAction(LoginActionFactory):

--- a/tests/actions/commands/test_logout.py
+++ b/tests/actions/commands/test_logout.py
@@ -1,7 +1,6 @@
 from unittest.mock import ANY
 
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import LogoutActionFactory
 
 

--- a/tests/actions/commands/test_logout.py
+++ b/tests/actions/commands/test_logout.py
@@ -1,7 +1,7 @@
 from unittest.mock import ANY
 
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import LogoutActionFactory
+from tests.actions.conftest import LogoutActionFactory
 
 
 class TestLogoutAction(LogoutActionFactory):

--- a/tests/actions/commands/test_look.py
+++ b/tests/actions/commands/test_look.py
@@ -1,8 +1,7 @@
 from unittest.mock import ANY
 
-from cibo.models.client import ClientLoginState
-from cibo.models.data.player import Player
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
+from cibo.models.data import Player
 from tests.conftest import LookActionFactory
 
 

--- a/tests/actions/commands/test_look.py
+++ b/tests/actions/commands/test_look.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY
 
 from cibo.models import ClientLoginState, Message, MessageRoute
 from cibo.models.data import Player
-from tests.conftest import LookActionFactory
+from tests.actions.conftest import LookActionFactory
 
 
 class TestLookAction(LookActionFactory):

--- a/tests/actions/commands/test_move.py
+++ b/tests/actions/commands/test_move.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import MoveActionFactory
+from tests.actions.conftest import MoveActionFactory
 
 
 class TestMoveAction(MoveActionFactory):

--- a/tests/actions/commands/test_move.py
+++ b/tests/actions/commands/test_move.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import MoveActionFactory
 
 

--- a/tests/actions/commands/test_open.py
+++ b/tests/actions/commands/test_open.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import OpenActionFactory
+from tests.actions.conftest import OpenActionFactory
 
 
 class TestOpenAction(OpenActionFactory):

--- a/tests/actions/commands/test_open.py
+++ b/tests/actions/commands/test_open.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import OpenActionFactory
 
 

--- a/tests/actions/commands/test_quit.py
+++ b/tests/actions/commands/test_quit.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import QuitActionFactory
+from tests.actions.conftest import QuitActionFactory
 
 
 class TestQuitAction(QuitActionFactory):

--- a/tests/actions/commands/test_quit.py
+++ b/tests/actions/commands/test_quit.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import QuitActionFactory
 
 

--- a/tests/actions/commands/test_register.py
+++ b/tests/actions/commands/test_register.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import RegisterActionFactory
 
 

--- a/tests/actions/commands/test_register.py
+++ b/tests/actions/commands/test_register.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import RegisterActionFactory
+from tests.actions.conftest import RegisterActionFactory
 
 
 class TestRegisterAction(RegisterActionFactory):

--- a/tests/actions/commands/test_say.py
+++ b/tests/actions/commands/test_say.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import SayActionFactory
+from tests.actions.conftest import SayActionFactory
 
 
 class TestSayAction(SayActionFactory):

--- a/tests/actions/commands/test_say.py
+++ b/tests/actions/commands/test_say.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import SayActionFactory
 
 

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -1,0 +1,179 @@
+from pytest import fixture
+
+from cibo.actions import Connect, Disconnect, Error
+from cibo.actions.commands import (
+    Close,
+    Drop,
+    Exits,
+    Finalize,
+    Get,
+    Inventory,
+    Login,
+    Logout,
+    Look,
+    Move,
+    Open,
+    Quit,
+    Register,
+    Say,
+)
+from cibo.actions.scheduled import EveryMinute, EverySecond
+from cibo.models import ClientLoginState
+from cibo.models.data import Player
+from cibo.models.server_config import ServerConfig
+from tests.conftest import (
+    BaseFactory,
+    ClientFactory,
+    DatabaseFactory,
+    MessageFactory,
+    WorldFactory,
+)
+
+
+class ActionFactory(ClientFactory, WorldFactory, MessageFactory):
+    def get_message_panel(self):
+        return self.output.send_to_client.call_args.args[0].message.body
+
+    @fixture
+    def _fixture_action(self, _fixture_world):
+        self.server_config = ServerConfig(self.telnet, self.world, self.output)
+        self.client.login_state = ClientLoginState.LOGGED_IN
+        yield
+
+
+class ConnectActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_connect(self, _fixture_action):
+        self.connect = Connect(self.server_config)
+        yield
+
+
+class DisconnectActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_disconnect(self, _fixture_action):
+        self.disconnect = Disconnect(self.server_config)
+        yield
+
+
+class ErrorActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_error(self, _fixture_action):
+        self.error = Error(self.server_config)
+        yield
+
+
+class CloseActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_close(self, _fixture_action):
+        self.close = Close(self.server_config)
+        yield
+
+
+class OpenActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_open(self, _fixture_action):
+        self.open = Open(self.server_config)
+        yield
+
+
+class MoveActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_move(self, _fixture_action):
+        self.telnet.get_connected_clients.return_value = []
+        self.move = Move(self.server_config)
+        yield
+
+
+class LookActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_look(self, _fixture_action):
+        self.look = Look(self.server_config)
+        yield
+
+
+class ExitsActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_exits(self, _fixture_action):
+        self.exits = Exits(self.server_config)
+        yield
+
+
+class SayActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_say(self, _fixture_action):
+        self.say = Say(self.server_config)
+        yield
+
+
+class QuitActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_quit(self, _fixture_action):
+        self.quit = Quit(self.server_config)
+        yield
+
+
+class LogoutActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_logout(self, _fixture_action):
+        self.logout = Logout(self.server_config)
+        yield
+
+
+class RegisterActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_register(self, _fixture_action):
+        self.client.login_state = ClientLoginState.PRE_LOGIN
+        self.register = Register(self.server_config)
+        yield
+
+
+class FinalizeActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_finalize(self, _fixture_action):
+        self.client.login_state = ClientLoginState.PRE_LOGIN
+        self.client.registration = Player()
+        self.finalize = Finalize(self.server_config)
+        yield
+
+
+class LoginActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_login(self, _fixture_action):
+        self.client.login_state = ClientLoginState.PRE_LOGIN
+        self.login = Login(self.server_config)
+        yield
+
+
+class InventoryActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_inventory(self, _fixture_action):
+        self.inventory = Inventory(self.server_config)
+        yield
+
+
+class DropActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_drop(self, _fixture_action):
+        self.drop = Drop(self.server_config)
+        yield
+
+
+class GetActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_get(self, _fixture_action):
+        self.get = Get(self.server_config)
+        yield
+
+
+class EveryMinuteActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_every_minute(self, _fixture_action):
+        self.every_minute = EveryMinute(self.server_config)
+        yield
+
+
+class EverySecondActionFactory(BaseFactory, ActionFactory):
+    @fixture(autouse=True)
+    def fixture_every_second(self, _fixture_action):
+        self.every_second = EverySecond(self.server_config)
+        yield

--- a/tests/actions/scheduled/test_every_minute.py
+++ b/tests/actions/scheduled/test_every_minute.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState
-from tests.conftest import EveryMinuteActionFactory
+from tests.actions.conftest import EveryMinuteActionFactory
 
 
 class TestEveryMinuteAction(EveryMinuteActionFactory):

--- a/tests/actions/scheduled/test_every_minute.py
+++ b/tests/actions/scheduled/test_every_minute.py
@@ -1,4 +1,4 @@
-from cibo.models.client import ClientLoginState
+from cibo.models import ClientLoginState
 from tests.conftest import EveryMinuteActionFactory
 
 

--- a/tests/actions/scheduled/test_every_second.py
+++ b/tests/actions/scheduled/test_every_second.py
@@ -1,4 +1,4 @@
-from tests.conftest import EverySecondActionFactory
+from tests.actions.conftest import EverySecondActionFactory
 
 
 class TestEverySecondAction(EverySecondActionFactory):

--- a/tests/actions/test_connect.py
+++ b/tests/actions/test_connect.py
@@ -1,4 +1,4 @@
-from tests.conftest import ConnectActionFactory
+from tests.actions.conftest import ConnectActionFactory
 
 
 class TestConnectAction(ConnectActionFactory):

--- a/tests/actions/test_disconnect.py
+++ b/tests/actions/test_disconnect.py
@@ -1,5 +1,4 @@
-from cibo.models.client import ClientLoginState
-from cibo.models.message import Message, MessageRoute
+from cibo.models import ClientLoginState, Message, MessageRoute
 from tests.conftest import DisconnectActionFactory
 
 

--- a/tests/actions/test_disconnect.py
+++ b/tests/actions/test_disconnect.py
@@ -1,5 +1,5 @@
 from cibo.models import ClientLoginState, Message, MessageRoute
-from tests.conftest import DisconnectActionFactory
+from tests.actions.conftest import DisconnectActionFactory
 
 
 class TestDisconnectAction(DisconnectActionFactory):

--- a/tests/actions/test_error.py
+++ b/tests/actions/test_error.py
@@ -1,5 +1,5 @@
 from cibo.models import Message, MessageRoute
-from tests.conftest import ErrorActionFactory
+from tests.actions.conftest import ErrorActionFactory
 
 
 class TestErrorAction(ErrorActionFactory):

--- a/tests/actions/test_error.py
+++ b/tests/actions/test_error.py
@@ -1,4 +1,4 @@
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import ErrorActionFactory
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,53 +5,56 @@ from unittest.mock import Mock
 from peewee import SqliteDatabase
 from pytest import fixture
 
-from cibo.actions.commands.close import Close
-from cibo.actions.commands.drop import Drop
-from cibo.actions.commands.exits import Exits
-from cibo.actions.commands.finalize import Finalize
-from cibo.actions.commands.get import Get
-from cibo.actions.commands.inventory import Inventory
-from cibo.actions.commands.login import Login
-from cibo.actions.commands.logout import Logout
-from cibo.actions.commands.look import Look
-from cibo.actions.commands.move import Move
-from cibo.actions.commands.open import Open
-from cibo.actions.commands.quit import Quit
-from cibo.actions.commands.register import Register
-from cibo.actions.commands.say import Say
-from cibo.actions.connect import Connect
-from cibo.actions.disconnect import Disconnect
-from cibo.actions.error import Error
-from cibo.actions.scheduled.every_minute import EveryMinute
-from cibo.actions.scheduled.every_second import EverySecond
+from cibo.actions import Connect, Disconnect, Error
+from cibo.actions.commands import (
+    Close,
+    Drop,
+    Exits,
+    Finalize,
+    Get,
+    Inventory,
+    Login,
+    Logout,
+    Look,
+    Move,
+    Open,
+    Quit,
+    Register,
+    Say,
+)
+from cibo.actions.scheduled import EveryMinute, EverySecond
 from cibo.command import CommandProcessor
-from cibo.events.connect import ConnectEvent
-from cibo.events.disconnect import DisconnectEvent
-from cibo.events.input import InputEvent
-from cibo.events.spawn import SpawnEvent
-from cibo.models.client import Client, ClientLoginState
-from cibo.models.data.item import Item as ItemData
-from cibo.models.data.npc import Npc as NpcData
-from cibo.models.data.player import Player
-from cibo.models.description import EntityDescription, RoomDescription
-from cibo.models.direction import Direction
-from cibo.models.door import Door, DoorFlag
-from cibo.models.flag import RoomFlag
-from cibo.models.item import Item
-from cibo.models.npc import Npc
-from cibo.models.region import Region
-from cibo.models.room import Room, RoomExit
-from cibo.models.sector import Sector
+from cibo.events import ConnectEvent, DisconnectEvent, InputEvent, SpawnEvent
+from cibo.models import (
+    Client,
+    ClientLoginState,
+    Direction,
+    Door,
+    DoorFlag,
+    EntityDescription,
+    Item,
+    Npc,
+    Region,
+    Room,
+    RoomDescription,
+    RoomExit,
+    RoomFlag,
+    Sector,
+    Spawn,
+    SpawnType,
+)
+from cibo.models.data import Item as ItemData
+from cibo.models.data import Npc as NpcData
+from cibo.models.data import Player
 from cibo.models.server_config import ServerConfig
-from cibo.models.spawn import Spawn, SpawnType
 from cibo.output import OutputProcessor
-from cibo.outputs.private import Private as OutputPrivate
-from cibo.outputs.region import Region as OutputRegion
-from cibo.outputs.room import Room as OutputRoom
-from cibo.outputs.sector import Sector as OutputSector
-from cibo.outputs.server import Server as OutputServer
+from cibo.outputs import Private as OutputPrivate
+from cibo.outputs import Region as OutputRegion
+from cibo.outputs import Room as OutputRoom
+from cibo.outputs import Sector as OutputSector
+from cibo.outputs import Server as OutputServer
 from cibo.password import Password
-from cibo.resources.world import World
+from cibo.resources import World
 
 
 class BaseFactory:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,26 +5,7 @@ from unittest.mock import Mock
 from peewee import SqliteDatabase
 from pytest import fixture
 
-from cibo.actions import Connect, Disconnect, Error
-from cibo.actions.commands import (
-    Close,
-    Drop,
-    Exits,
-    Finalize,
-    Get,
-    Inventory,
-    Login,
-    Logout,
-    Look,
-    Move,
-    Open,
-    Quit,
-    Register,
-    Say,
-)
-from cibo.actions.scheduled import EveryMinute, EverySecond
 from cibo.command import CommandProcessor
-from cibo.events import ConnectEvent, DisconnectEvent, InputEvent, SpawnEvent
 from cibo.models import (
     Client,
     ClientLoginState,
@@ -182,16 +163,76 @@ class WorldFactory:
         yield
 
 
+class MessageFactory:
+    @fixture(autouse=True)
+    def _fixture_message(self):
+        self.default_message_args = {
+            "justify": None,
+            "style": None,
+            "highlight": False,
+            "terminal_width": 76,
+        }
+        yield
+
+
 class OutputFactory(BaseFactory, ClientFactory, WorldFactory):
     @fixture(autouse=True)
     def fixture_output(self):
+        self.telnet.get_connected_clients.return_value = [self.mock_clients[0]]
         self.output = OutputProcessor(self.telnet, self.world)
         self.private = OutputPrivate(self.telnet, self.world)
         self.room = OutputRoom(self.telnet, self.world)
         self.sector = OutputSector(self.telnet, self.world)
         self.region = OutputRegion(self.telnet, self.world)
         self.server = OutputServer(self.telnet, self.world)
-        self.telnet.get_connected_clients.return_value = [self.mock_clients[0]]
+        yield
+
+
+class DoorFactory(WorldFactory):
+    @fixture(autouse=True)
+    def fixture_door(self):
+        self.door_closed = Door(
+            name="a wooden door", room_ids=[1, 2], flags=[DoorFlag.CLOSED]
+        )
+        self.door_open = Door(
+            name="a wooden door", room_ids=[1, 2], flags=[DoorFlag.OPEN]
+        )
+        self.door_locked = Door(
+            name="a steel security door",
+            room_ids=[1, 4],
+            flags=[DoorFlag.LOCKED],
+        )
+        yield
+
+
+class ItemFactory(WorldFactory):
+    @fixture(autouse=True)
+    def fixture_item(self):
+        self.item = Item(
+            id_=1,
+            name="a metal fork",
+            description=EntityDescription(
+                room="glistens in the dirt.",
+                look="A pronged, metal eating utensil.",
+            ),
+            is_stationary=False,
+            carry_limit=0,
+            weight=0,
+        )
+        yield
+
+
+class NpcFactory(WorldFactory):
+    @fixture(autouse=True)
+    def fixture_npc(self):
+        self.npc = Npc(
+            id_=1,
+            name="a faceless businessman",
+            description=EntityDescription(
+                room="sits at his desk.",
+                look="His face is smooth and amorphis, like putty. He is wearing a suit, tie, and carrying a briefcase. Though he has no eyes, he seems to be aware of your presence.",
+            ),
+        )
         yield
 
 
@@ -245,40 +286,6 @@ class RoomFactory(SectorFactory):
         yield
 
 
-class DoorFactory(WorldFactory):
-    @fixture(autouse=True)
-    def fixture_door(self):
-        self.door_closed = Door(
-            name="a wooden door", room_ids=[1, 2], flags=[DoorFlag.CLOSED]
-        )
-        self.door_open = Door(
-            name="a wooden door", room_ids=[1, 2], flags=[DoorFlag.OPEN]
-        )
-        self.door_locked = Door(
-            name="a steel security door",
-            room_ids=[1, 4],
-            flags=[DoorFlag.LOCKED],
-        )
-        yield
-
-
-class ItemFactory(WorldFactory):
-    @fixture(autouse=True)
-    def fixture_item(self):
-        self.item = Item(
-            id_=1,
-            name="a metal fork",
-            description=EntityDescription(
-                room="glistens in the dirt.",
-                look="A pronged, metal eating utensil.",
-            ),
-            is_stationary=False,
-            carry_limit=0,
-            weight=0,
-        )
-        yield
-
-
 class SpawnFactory(WorldFactory):
     @fixture(autouse=True)
     def _fixture_spawn(self):
@@ -287,215 +294,4 @@ class SpawnFactory(WorldFactory):
             Spawn(type_=SpawnType.ITEM, entity_id=2, room_id=1, amount=1),
             Spawn(type_=SpawnType.NPC, entity_id=1, room_id=1, amount=1),
         ]
-        yield
-
-
-class NpcFactory(WorldFactory):
-    @fixture(autouse=True)
-    def fixture_npc(self):
-        self.npc = Npc(
-            id_=1,
-            name="a faceless businessman",
-            description=EntityDescription(
-                room="sits at his desk.",
-                look="His face is smooth and amorphis, like putty. He is wearing a suit, tie, and carrying a briefcase. Though he has no eyes, he seems to be aware of your presence.",
-            ),
-        )
-        yield
-
-
-class ConnectEventFactory(BaseFactory):
-    @fixture(autouse=True)
-    def fixture_connect_event(self):
-        self.connect = ConnectEvent(self.server_config)
-        yield
-
-
-class DisconnectEventFactory(BaseFactory, ClientFactory):
-    @fixture(autouse=True)
-    def fixture_disconnect_event(self):
-        self.client.login_state = ClientLoginState.LOGGED_IN
-        self.disconnect = DisconnectEvent(self.server_config)
-        self.default_message_args = {
-            "justify": None,
-            "style": None,
-            "highlight": False,
-            "terminal_width": 76,
-        }
-        yield
-
-
-class SpawnEventFactory(BaseFactory, WorldFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_spawn_event(self):
-        self.server_config = ServerConfig(self.telnet, self.world, self.output)
-        self.spawn = SpawnEvent(self.server_config)
-        yield
-
-
-class InputEventFactory(CommandProcessorFactory, ClientFactory):
-    @fixture(autouse=True)
-    def fixture_input_event(self):
-        self.input = InputEvent(self.server_config, self.command_processor)
-        self.default_message_args = {
-            "justify": None,
-            "style": None,
-            "highlight": False,
-            "terminal_width": 76,
-        }
-        yield
-
-
-class ActionFactory(ClientFactory, WorldFactory):
-    def get_message_panel(self):
-        return self.output.send_to_client.call_args.args[0].message.body
-
-    @fixture
-    def _fixture_action(self, _fixture_world):
-        self.server_config = ServerConfig(self.telnet, self.world, self.output)
-        self.client.login_state = ClientLoginState.LOGGED_IN
-        self.default_message_args = {
-            "justify": None,
-            "style": None,
-            "highlight": False,
-            "terminal_width": 76,
-        }
-        yield
-
-
-class ConnectActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_connect(self, _fixture_action):
-        self.connect = Connect(self.server_config)
-        yield
-
-
-class DisconnectActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_disconnect(self, _fixture_action):
-        self.disconnect = Disconnect(self.server_config)
-        yield
-
-
-class ErrorActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_error(self, _fixture_action):
-        self.error = Error(self.server_config)
-        yield
-
-
-class CloseActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_close(self, _fixture_action):
-        self.close = Close(self.server_config)
-        yield
-
-
-class OpenActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_open(self, _fixture_action):
-        self.open = Open(self.server_config)
-        yield
-
-
-class MoveActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_move(self, _fixture_action):
-        self.telnet.get_connected_clients.return_value = []
-        self.move = Move(self.server_config)
-        yield
-
-
-class LookActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_look(self, _fixture_action):
-        self.look = Look(self.server_config)
-        yield
-
-
-class ExitsActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_exits(self, _fixture_action):
-        self.exits = Exits(self.server_config)
-        yield
-
-
-class SayActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_say(self, _fixture_action):
-        self.say = Say(self.server_config)
-        yield
-
-
-class QuitActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_quit(self, _fixture_action):
-        self.quit = Quit(self.server_config)
-        yield
-
-
-class LogoutActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_logout(self, _fixture_action):
-        self.logout = Logout(self.server_config)
-        yield
-
-
-class RegisterActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_register(self, _fixture_action):
-        self.client.login_state = ClientLoginState.PRE_LOGIN
-        self.register = Register(self.server_config)
-        yield
-
-
-class FinalizeActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_finalize(self, _fixture_action):
-        self.client.login_state = ClientLoginState.PRE_LOGIN
-        self.client.registration = Player()
-        self.finalize = Finalize(self.server_config)
-        yield
-
-
-class LoginActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_login(self, _fixture_action):
-        self.client.login_state = ClientLoginState.PRE_LOGIN
-        self.login = Login(self.server_config)
-        yield
-
-
-class InventoryActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_inventory(self, _fixture_action):
-        self.inventory = Inventory(self.server_config)
-        yield
-
-
-class DropActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_drop(self, _fixture_action):
-        self.drop = Drop(self.server_config)
-        yield
-
-
-class GetActionFactory(BaseFactory, ActionFactory, DatabaseFactory):
-    @fixture(autouse=True)
-    def fixture_get(self, _fixture_action):
-        self.get = Get(self.server_config)
-        yield
-
-
-class EveryMinuteActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_every_minute(self, _fixture_action):
-        self.every_minute = EveryMinute(self.server_config)
-        yield
-
-
-class EverySecondActionFactory(BaseFactory, ActionFactory):
-    @fixture(autouse=True)
-    def fixture_every_second(self, _fixture_action):
-        self.every_second = EverySecond(self.server_config)
         yield

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -1,0 +1,43 @@
+from pytest import fixture
+
+from cibo.events import ConnectEvent, DisconnectEvent, InputEvent, SpawnEvent
+from cibo.models import ClientLoginState
+from cibo.models.server_config import ServerConfig
+from tests.conftest import (
+    BaseFactory,
+    ClientFactory,
+    CommandProcessorFactory,
+    DatabaseFactory,
+    MessageFactory,
+    WorldFactory,
+)
+
+
+class ConnectEventFactory(BaseFactory):
+    @fixture(autouse=True)
+    def fixture_connect_event(self):
+        self.connect = ConnectEvent(self.server_config)
+        yield
+
+
+class DisconnectEventFactory(BaseFactory, ClientFactory, MessageFactory):
+    @fixture(autouse=True)
+    def fixture_disconnect_event(self):
+        self.client.login_state = ClientLoginState.LOGGED_IN
+        self.disconnect = DisconnectEvent(self.server_config)
+        yield
+
+
+class InputEventFactory(CommandProcessorFactory, ClientFactory, MessageFactory):
+    @fixture(autouse=True)
+    def fixture_input_event(self):
+        self.input = InputEvent(self.server_config, self.command_processor)
+        yield
+
+
+class SpawnEventFactory(BaseFactory, WorldFactory, DatabaseFactory):
+    @fixture(autouse=True)
+    def fixture_spawn_event(self):
+        self.server_config = ServerConfig(self.telnet, self.world, self.output)
+        self.spawn = SpawnEvent(self.server_config)
+        yield

--- a/tests/events/test_connect.py
+++ b/tests/events/test_connect.py
@@ -1,4 +1,4 @@
-from tests.conftest import ClientFactory, ConnectEventFactory
+from tests.events.conftest import ClientFactory, ConnectEventFactory
 
 
 class TestConnectEvent(ClientFactory, ConnectEventFactory):

--- a/tests/events/test_disconnect.py
+++ b/tests/events/test_disconnect.py
@@ -1,5 +1,5 @@
 from cibo.models import Message, MessageRoute
-from tests.conftest import DisconnectEventFactory
+from tests.events.conftest import DisconnectEventFactory
 
 
 class TestDisconnectEvent(DisconnectEventFactory):

--- a/tests/events/test_disconnect.py
+++ b/tests/events/test_disconnect.py
@@ -1,4 +1,4 @@
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import DisconnectEventFactory
 
 

--- a/tests/events/test_input.py
+++ b/tests/events/test_input.py
@@ -1,6 +1,6 @@
 import logging
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import InputEventFactory
 
 

--- a/tests/events/test_input.py
+++ b/tests/events/test_input.py
@@ -1,7 +1,7 @@
 import logging
 
 from cibo.models import Message, MessageRoute
-from tests.conftest import InputEventFactory
+from tests.events.conftest import InputEventFactory
 
 
 class TestInputEevent(InputEventFactory):

--- a/tests/events/test_spawn.py
+++ b/tests/events/test_spawn.py
@@ -1,5 +1,5 @@
 from cibo.models.data import Item
-from tests.conftest import SpawnEventFactory
+from tests.events.conftest import SpawnEventFactory
 
 
 class TestSpawnEvent(SpawnEventFactory):

--- a/tests/events/test_spawn.py
+++ b/tests/events/test_spawn.py
@@ -1,4 +1,4 @@
-from cibo.models.data.item import Item
+from cibo.models.data import Item
 from tests.conftest import SpawnEventFactory
 
 

--- a/tests/models/data/test_item.py
+++ b/tests/models/data/test_item.py
@@ -1,4 +1,4 @@
-from cibo.models.data.item import Item
+from cibo.models.data import Item
 from tests.conftest import DatabaseFactory
 
 

--- a/tests/models/data/test_npc.py
+++ b/tests/models/data/test_npc.py
@@ -1,4 +1,4 @@
-from cibo.models.data.npc import Npc
+from cibo.models.data import Npc
 from tests.conftest import DatabaseFactory
 
 

--- a/tests/models/data/test_player.py
+++ b/tests/models/data/test_player.py
@@ -1,7 +1,7 @@
 from pytest import raises
 
 from cibo.exception import PlayerNotFound
-from cibo.models.data.player import Player
+from cibo.models.data import Player
 from tests.conftest import DatabaseFactory
 
 

--- a/tests/models/test_client.py
+++ b/tests/models/test_client.py
@@ -1,9 +1,8 @@
 import socket as socket_
 from unittest.mock import Mock
 
-from cibo.models.client import ClientLoginState
-from cibo.models.data.player import Player
-from cibo.models.prompt import Prompt
+from cibo.models import ClientLoginState, Prompt
+from cibo.models.data import Player
 from tests.conftest import ClientFactory
 
 

--- a/tests/models/test_door.py
+++ b/tests/models/test_door.py
@@ -1,7 +1,7 @@
 from pytest import raises
 
 from cibo.exception import DoorIsClosed, DoorIsLocked, DoorIsOpen
-from cibo.models.door import Door, DoorFlag
+from cibo.models import Door, DoorFlag
 from tests.conftest import DoorFactory
 
 

--- a/tests/models/test_room.py
+++ b/tests/models/test_room.py
@@ -1,8 +1,7 @@
 from pytest import raises
 
 from cibo.exception import ExitNotFound
-from cibo.models.direction import Direction
-from cibo.models.room import RoomExit
+from cibo.models import Direction, RoomExit
 from tests.conftest import RoomFactory
 
 

--- a/tests/outputs/test_private.py
+++ b/tests/outputs/test_private.py
@@ -1,4 +1,4 @@
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import OutputFactory
 
 

--- a/tests/outputs/test_region.py
+++ b/tests/outputs/test_region.py
@@ -1,4 +1,4 @@
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import OutputFactory
 
 

--- a/tests/outputs/test_room.py
+++ b/tests/outputs/test_room.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import OutputFactory
 
 

--- a/tests/outputs/test_sector.py
+++ b/tests/outputs/test_sector.py
@@ -1,4 +1,4 @@
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import OutputFactory
 
 

--- a/tests/outputs/test_server.py
+++ b/tests/outputs/test_server.py
@@ -1,4 +1,4 @@
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import OutputFactory
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from pytest import raises
 
 from cibo.exception import MessageRouteMissingParameters
-from cibo.models.message import Message, MessageRoute
+from cibo.models import Message, MessageRoute
 from tests.conftest import OutputFactory
 
 


### PR DESCRIPTION
* leverage `__init__.py` files in subdirs to expose child classes to other modules, in a manner that they can be imported using shorter paths
* partially split up `./tests/conftest.py` to reduce bulk

Closes #35 