### PR TITLE
Fix Changelog Push Branch Target

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -2,7 +2,7 @@ name: 'Update Changelog'
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [closed]
   release:
     types: [published]
 
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   pull-request-update-changelog:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event.pull_request.merged == true
     name: "Update Changelog"
     runs-on: ubuntu-latest
 
@@ -39,15 +39,9 @@ jobs:
 
     - name: 'Push Changes'
       uses: stefanzweifel/git-auto-commit-action@v5
-      id: auto-commit
       with:
         commit_message: 'Update Changelog (!automated)'
         branch: master
-
-    - name: Run latest-tag
-      uses: EndBug/latest-tag@latest
-      with:
-        ref: '1.0.0-pre-alpha.2'
 
   release-update-changelog:
     if: github.event_name == 'release'
@@ -65,6 +59,7 @@ jobs:
     - name: 'Checkout Branch'
       uses: actions/checkout@v4
       with:
+        ref: master
         fetch-depth: 0
         token: ${{ steps.token-generator.outputs.token }}
 
@@ -79,3 +74,9 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: 'Update Changelog (!automated)'
+        branch: master
+
+    - name: 'Retag Release'
+      uses: EndBug/latest-tag@latest
+      with:
+        ref: ${{ github.event.release.tag_name }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -26,7 +26,7 @@ jobs:
     - name: 'Checkout Branch'
       uses: actions/checkout@v4
       with:
-        ref: '1.0.0-pre-alpha.2'
+        ref: master
         fetch-depth: 0
         token: ${{ steps.token-generator.outputs.token }}
 
@@ -39,12 +39,17 @@ jobs:
 
     - name: 'Push Changes'
       uses: stefanzweifel/git-auto-commit-action@v5
+      id: auto-commit
       with:
         commit_message: 'Update Changelog (!automated)'
-        branch: '1.0.0-pre-alpha.2'
-        skip_dirty_check: true    
-        skip_fetch: true    
-        skip_checkout: true
+        branch: master
+
+    - name: 'Update Tag'
+      if: steps.auto-commit.outputs.changes_detected == 'true'
+      run: |
+        git fetch —tags -f
+        git tag -f 1.0.0-pre-alpha.2 ${{ steps.auto-commit.outputs.commit_hash }}
+        git push origin 1.0.0-pre-alpha.2 --force
 
   release-update-changelog:
     if: github.event_name == 'release'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -29,6 +29,10 @@ jobs:
         ref: '1.0.0-pre-alpha.2'
         fetch-depth: 0
         token: ${{ steps.token-generator.outputs.token }}
+    
+    - name: 'Pull Tags'
+      run: |
+        git pull --tags -f
 
     - name: 'Initialize Environment'
       uses: ./.github/actions/initialize-environment

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -26,7 +26,7 @@ jobs:
     - name: 'Checkout Branch'
       uses: actions/checkout@v4
       with:
-        ref: master
+        ref: '1.0.0-pre-alpha.2'
         fetch-depth: 0
         token: ${{ steps.token-generator.outputs.token }}
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -44,12 +44,10 @@ jobs:
         commit_message: 'Update Changelog (!automated)'
         branch: master
 
-    - name: 'Update Tag'
-      if: steps.auto-commit.outputs.changes_detected == 'true'
-      run: |
-        git fetch —tags -f
-        git tag -f 1.0.0-pre-alpha.2 ${{ steps.auto-commit.outputs.commit_hash }}
-        git push origin 1.0.0-pre-alpha.2 --force
+    - name: Run latest-tag
+      uses: EndBug/latest-tag@latest
+      with:
+        ref: '1.0.0-pre-alpha.2'
 
   release-update-changelog:
     if: github.event_name == 'release'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -38,6 +38,7 @@ jobs:
         make generate_changelog
 
     - name: 'Push Changes'
+      if: success()
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: 'Update Changelog (!automated)'
@@ -71,12 +72,14 @@ jobs:
         make generate_changelog
 
     - name: 'Push Changes'
+      if: success()
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: 'Update Changelog (!automated)'
         branch: master
 
     - name: 'Retag Release'
+      if: success()
       uses: EndBug/latest-tag@latest
       with:
         ref: ${{ github.event.release.tag_name }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -29,10 +29,6 @@ jobs:
         ref: '1.0.0-pre-alpha.2'
         fetch-depth: 0
         token: ${{ steps.token-generator.outputs.token }}
-    
-    - name: 'Pull Tags'
-      run: |
-        git pull --tags -f
 
     - name: 'Initialize Environment'
       uses: ./.github/actions/initialize-environment
@@ -46,6 +42,9 @@ jobs:
       with:
         commit_message: 'Update Changelog (!automated)'
         branch: '1.0.0-pre-alpha.2'
+        skip_dirty_check: true    
+        skip_fetch: true    
+        skip_checkout: true
 
   release-update-changelog:
     if: github.event_name == 'release'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -41,8 +41,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: 'Update Changelog (!automated)'
-        branch: master
-        tagging_message: '1.0.0-pre-alpha.2'
+        branch: '1.0.0-pre-alpha.2'
 
   release-update-changelog:
     if: github.event_name == 'release'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -2,7 +2,7 @@ name: 'Update Changelog'
 
 on:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize]
   release:
     types: [published]
 
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   pull-request-update-changelog:
-    if: github.event_name == 'pull_request' || github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request'
     name: "Update Changelog"
     runs-on: ubuntu-latest
 
@@ -42,6 +42,7 @@ jobs:
       with:
         commit_message: 'Update Changelog (!automated)'
         branch: master
+        tagging_message: '1.0.0-pre-alpha.2'
 
   release-update-changelog:
     if: github.event_name == 'release'


### PR DESCRIPTION
* return to just using `master` as a reference on release, but instead retagging the release tag to the newest commit after the changelog has been updated.